### PR TITLE
Refactor latest runs

### DIFF
--- a/cli/src/main/kotlin/tech/coner/trailer/cli/command/event/run/EventRunLatestCommand.kt
+++ b/cli/src/main/kotlin/tech/coner/trailer/cli/command/event/run/EventRunLatestCommand.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.validate
 import com.github.ajalt.clikt.parameters.types.int
 import java.util.UUID
 import org.kodein.di.DI
@@ -12,6 +13,7 @@ import tech.coner.trailer.cli.command.BaseCommand
 import tech.coner.trailer.cli.command.GlobalModel
 import tech.coner.trailer.cli.util.clikt.toUuid
 import tech.coner.trailer.di.Format
+import tech.coner.trailer.io.service.EventContextService
 import tech.coner.trailer.io.service.EventService
 import tech.coner.trailer.io.service.RunService
 import tech.coner.trailer.render.RunRenderer
@@ -29,15 +31,18 @@ class EventRunLatestCommand(
     override val diContext = diContextDataSession()
 
     private val eventService: EventService by instance()
-    private val runService: RunService by instance()
+    private val eventContextService: EventContextService by instance()
     private val renderer: RunRenderer by instance { Format.TEXT }
 
     private val eventId: UUID by argument().convert { toUuid(it) }
     private val count: Int by option().int().default(5)
+        .validate { if (it < 1) fail("Count must be greater than or equal to 1") }
 
     override suspend fun coRun() {
         val event = eventService.findByKey(eventId).getOrThrow()
-        val runs = runService.latest(event, count).getOrThrow()
-        echo(renderer.render(runs))
+        val eventContext = eventContextService.load(event).getOrThrow()
+        // really a presentation concern
+        val latestRuns = eventContext.runs.takeLast(count)
+        echo(renderer.render(latestRuns))
     }
 }

--- a/cli/src/test/kotlin/tech/coner/trailer/cli/command/event/run/EventRunLatestCommandTest.kt
+++ b/cli/src/test/kotlin/tech/coner/trailer/cli/command/event/run/EventRunLatestCommandTest.kt
@@ -1,0 +1,112 @@
+package tech.coner.trailer.cli.command.event.run
+
+import assertk.all
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.messageContains
+import com.github.ajalt.clikt.core.BadParameterValue
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.kodein.di.DI
+import org.kodein.di.instance
+import tech.coner.trailer.Event
+import tech.coner.trailer.EventContext
+import tech.coner.trailer.TestEventContexts
+import tech.coner.trailer.TestEvents
+import tech.coner.trailer.cli.clikt.error
+import tech.coner.trailer.cli.clikt.output
+import tech.coner.trailer.cli.command.BaseDataSessionCommandTest
+import tech.coner.trailer.cli.command.GlobalModel
+import tech.coner.trailer.di.Format
+import tech.coner.trailer.io.service.EventContextService
+import tech.coner.trailer.io.service.EventService
+import tech.coner.trailer.render.RunRenderer
+
+class EventRunLatestCommandTest : BaseDataSessionCommandTest<EventRunLatestCommand>() {
+
+    private val eventService: EventService by instance()
+    private val eventContextService: EventContextService by instance()
+    private val renderer: RunRenderer by instance { Format.TEXT }
+
+    private val rendered = "rendered"
+
+    override fun createCommand(di: DI, global: GlobalModel) = EventRunLatestCommand(di, global)
+
+    @Test
+    fun `It should echo 5 latest runs by default`() {
+        val eventContext = TestEventContexts.Lscc2019Simplified.points1
+        arrangeValidEvent(eventContext)
+
+        command.parse(arrayOf("${eventContext.event.id}"))
+
+        assertThat(testConsole).all {
+            output().isEqualTo(rendered)
+            error().isEmpty()
+        }
+        coVerifySequence {
+            eventService.findByKey(eventContext.event.id)
+            eventContextService.load(eventContext.event)
+            renderer.render(eventContext.runs.takeLast(5))
+        }
+        confirmVerified(eventService, eventContextService, renderer)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [1, 2, 4, 8, 16, 32, 64])
+    fun `It should echo specified latest runs`(count: Int) {
+        val eventContext = TestEventContexts.Lscc2019Simplified.points1
+        arrangeValidEvent(eventContext)
+
+        command.parse(arrayOf(
+            "--count", "$count",
+            "${eventContext.event.id}"
+        ))
+
+        assertThat(testConsole).all {
+            output().isEqualTo(rendered)
+            error().isEmpty()
+        }
+        coVerifySequence {
+            eventService.findByKey(eventContext.event.id)
+            eventContextService.load(eventContext.event)
+            renderer.render(eventContext.runs.takeLast(count))
+        }
+        confirmVerified(eventService, eventContextService, renderer)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, -1, -2, -4, -8, -16, -32, -64])
+    fun `It should fail to validate when specified count is less than 1`(count: Int) {
+        val eventContext = TestEventContexts.Lscc2019Simplified.points1
+        arrangeValidEvent(eventContext)
+
+        assertFailure {
+            command.parse(arrayOf(
+                "--count", "$count",
+                "${eventContext.event.id}"
+            ))
+        }
+            .isInstanceOf(BadParameterValue::class)
+            .all {
+                messageContains("--count")
+                messageContains("Count must be greater than or equal to 1")
+            }
+
+        assertThat(testConsole).all {
+            output().isEmpty()
+            error().isEmpty()
+        }
+        confirmVerified(eventService, eventContextService, renderer)
+    }
+
+    private fun arrangeValidEvent(eventContext: EventContext) {
+        coEvery { eventService.findByKey(any()) } returns Result.success(eventContext.event)
+        coEvery { eventContextService.load(any()) } returns Result.success(eventContext)
+        every { renderer.render(runs = any()) } returns rendered
+    }
+}

--- a/io/src/main/kotlin/tech/coner/trailer/io/service/RunService.kt
+++ b/io/src/main/kotlin/tech/coner/trailer/io/service/RunService.kt
@@ -1,9 +1,9 @@
 package tech.coner.trailer.io.service
 
-import kotlin.coroutines.CoroutineContext
 import tech.coner.trailer.Event
 import tech.coner.trailer.Policy
 import tech.coner.trailer.Run
+import kotlin.coroutines.CoroutineContext
 
 class RunService(
     coroutineContext: CoroutineContext,
@@ -15,10 +15,4 @@ class RunService(
             Policy.DataSource.CrispyFish -> crispyFishRunService.list(event)
         }
     }
-
-    suspend fun latest(event: Event, count: Int): Result<List<Run>> = when (event.policy.requireAuthoritativeRunDataSource()) {
-        Policy.DataSource.CrispyFish -> crispyFishRunService.list(event)
-    }
-        .map { it.sortedBy(Run::sequence) }
-        .map { it.takeLast(count) }
 }


### PR DESCRIPTION
Latest Runs is a presentation concern

- Moved the takeLatest from service to EventRunLatestCommand
- Noted the presentation concern in the command
- Use EventContext instead of List<Run> (will simplify presentation adapter)
- Unit test for EventRunLatestCommand